### PR TITLE
Insufficient escaping of percent sign in systemd unit file

### DIFF
--- a/templates/slapd.service.j2
+++ b/templates/slapd.service.j2
@@ -6,7 +6,7 @@ OnFailure=unit-failed@%n.service
 
 [Service]
 Type=forking
-ExecStart=/usr/sbin/slapd -u {{ slapd_user }} -g {{ slapd_group }} -F {{ slapd_olc_dir }} -h 'ldapi://{{ slapd_ldapi_socket | urlencode() | regex_replace('/', '%2F') }} ldap://[::] ldaps://[::]'
+ExecStart=/usr/sbin/slapd -u {{ slapd_user }} -g {{ slapd_group }} -F {{ slapd_olc_dir }} -h 'ldapi://{{ slapd_ldapi_socket | urlencode() | regex_replace('/', '%%2F') }} ldap://[::] ldaps://[::]'
 PIDFile={{ slapd_run_dir }}/slapd.pid
 SyslogFacility=local4
 # Security


### PR DESCRIPTION
As per the systemd documentation at:

https://www.freedesktop.org/software/systemd/man/systemd.unit.html

double %% encoding is needed in systemd unit files, apparently this didn't use to be a problem with Ubuntu 16.04, but it prevents slapd from starting in 18.04:

https://askubuntu.com/questions/1028898/systemd-service-startup-script-worked-in-16-04-but-throws-an-error-in-18-04
