### PR TITLE
Remove deprecation warnings for apt and sudo

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,12 +7,10 @@
 
 - name: Install required packages (apt)
   apt:
-    name: "{{ packages }}"
-  vars:
-    packages:
-    - slapd
-    - ldap-utils
-    - schema2ldif
+    name:
+      - slapd
+      - ldap-utils
+      - schema2ldif
   when: ansible_pkg_mgr == "apt"
 
 - name: Update repositories cache (pacman)
@@ -23,10 +21,8 @@
 
 - name: Install required packages (pacman)
   pacman:
-    name: "{{ packages }}"
-  vars:
-    packages:
-    - openldap
+    name: 
+      - openldap
   when: ansible_pkg_mgr == "pacman"
 
 - name: Get schema2ldif

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -7,8 +7,9 @@
 
 - name: Install required packages (apt)
   apt:
-    name: "{{ item }}"
-  with_items:
+    name: "{{ packages }}"
+  vars:
+    packages:
     - slapd
     - ldap-utils
     - schema2ldif
@@ -22,8 +23,9 @@
 
 - name: Install required packages (pacman)
   pacman:
-    name: "{{ item }}"
-  with_items:
+    name: "{{ packages }}"
+  vars:
+    packages:
     - openldap
   when: ansible_pkg_mgr == "pacman"
 

--- a/tasks/olc-setup.yml
+++ b/tasks/olc-setup.yml
@@ -37,8 +37,9 @@
 
 # Not using become the user may be overridden
 - name: Apply basic OLC configuration
-  command: "/usr/bin/sudo -u {{ slapd_user }} /usr/sbin/slaptest -f {{ olc_tmp }} -F {{ slapd_olc_dir }}"
+  command: "/usr/sbin/slaptest -f {{ olc_tmp }} -F {{ slapd_olc_dir }}"
   when: not olccreated.stat.exists
+  become_user: "{{ slapd_user }}"
 
 - name: Clean OLC configuration
   file:


### PR DESCRIPTION
there were two warnings in this role.
1. deprecated "with_items" for apt -> variables
2. usage of sudo command -> become